### PR TITLE
Place assets into bin dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ add_custom_target (flash DEPENDS ${PROJECT_NAME}.flash)
 
 # setup release packages
 include (${CMAKE_CURRENT_BINARY_DIR}/assets.cmake)
-install (FILES ${ASSET_OUTPUTS} DESTINATION assets/)
+install (FILES ${ASSET_OUTPUTS} DESTINATION bin)
 install (FILES ${PROJECT_DISTRIBS} DESTINATION .)
 install (DIRECTORY ${PROJECT_EXAMPLES} DESTINATION .)
 set (CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)


### PR DESCRIPTION
Makes it easier to run an example since the binary wont look for assets in ../assets/ and also wont look for them in the working directory if you `../bin/32blit-lua --launch_path examples/example.lua`