### PR TITLE
Surface support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ set(PROJECT_SOURCE
   lua-bindings/rect.cpp
   lua-bindings/sprites.cpp
   lua-bindings/timer.cpp
+  lua-bindings/palette.cpp
+  lua-bindings/surface.cpp
   lua-bindings/screen.cpp)
 
 set(PROJECT_DISTRIBS

--- a/examples/surface.lua
+++ b/examples/surface.lua
@@ -1,0 +1,60 @@
+source_rect = Rect(0, 0, 70, 14)
+surface = nil
+surface_test = nil
+offset = nil
+overlay = nil
+overlay_rect = nil
+
+function init()
+    set_screen_mode(ScreenMode.hires)
+
+    overlay_rect = Rect(Point(0, 0), screen.bounds)
+    overlay = Surface(screen.bounds, PixelFormat.P)
+    overlay.palette[0] = Pen(0, 0, 0, 0)
+    overlay.palette[1] = Pen(255, 0, 0, 255)
+    overlay.pen = Pen(0)
+    overlay:clear()
+
+    surface_test = Surface(source_rect.size)
+    -- Test surface must be cleared with an opaque colour
+    -- or blitting into it wont work- will just be transparent!
+    surface_test.pen = Pen(0, 255, 0, 255)
+    surface_test:clear()
+
+
+    surface = Surface(source_rect.size)
+    offset = overlay_rect.center - source_rect.center
+
+    surface.pen = Pen(255, 255, 0)
+    surface:clear()
+
+    surface.pen = Pen(0, 0, 0)
+    surface:text("Hello World", outline_font, source_rect.center, true, TextAlign.center_center)
+end
+
+function update(time)
+end
+
+function render(time)
+    r = 50
+    t = time / 1000
+    ty = time / 2000
+    tx = time / 500
+    time_offset = Point(math.sin(t) * r, math.cos(t) * r) -- whoosh round and round
+    time_offset.y = time_offset.y + (math.sin(ty) * 50)   -- up down wiggle
+    time_offset.x = time_offset.x + (math.sin(tx) * 50)   -- left right wiggle
+    dest_rect = Rect(
+        offset + time_offset,
+        Size(70 + (math.sin(tx) * 35), 14 + (math.sin(ty) * 7)))
+
+    screen.pen = Pen(0, 0, 0)
+    screen.clear()
+
+    overlay.pen = Pen(1)
+    overlay:pixel(offset + time_offset + source_rect.center)
+
+    surface_test:blit(surface, source_rect, Point(0, 0))
+
+    screen.blit(overlay, overlay_rect, Point(0, 0))
+    screen.stretch_blit(surface_test, source_rect, dest_rect)
+end

--- a/lua-bindings/palette.cpp
+++ b/lua-bindings/palette.cpp
@@ -1,0 +1,59 @@
+#include "../luablitlib.hpp"
+
+using namespace blit;
+
+static int palette_new(lua_State* L){
+    new(lua_newuserdata(L, sizeof(Palette))) Palette{new Pen[256]};
+    luaL_setmetatable(L, LUA_BLIT_PALETTE);
+    return 1;
+}
+
+static int palette_delete(lua_State* L){
+    //auto palette = reinterpret_cast<Palette*>(lua_touserdata(L, 1));
+    return 0;
+}
+
+static int palette_index(lua_State* L){
+    int nargs = lua_gettop(L);
+    auto palette = reinterpret_cast<Palette*>(lua_touserdata(L, 1));
+    if(lua_isinteger(L, 2)) {
+        auto index = lua_tointeger(L, 2);
+        if(index >= 0 && index <= 255) {
+            if(nargs == 3) {
+                auto pen = lua_blit_checkpen(L, 3);
+                palette->entries[index] = *pen;
+                return 0;
+            } else {
+                lua_blit_pushpen(L, palette->entries[index]); return 1;
+            }
+        }
+        luaL_error(L, "Index `%d` out of range on %s", index, LUA_BLIT_PALETTE);
+    } else {
+        std::string_view method = luaL_checkstring(L, 2);
+        luaL_error(L, "Unknown property or method `%s` on %s", method.data(), LUA_BLIT_PALETTE);
+    }
+    return 0;
+}
+
+void lua_blit_pushpalette(lua_State *L, Pen *p) {
+    new(lua_newuserdata(L, sizeof(Palette))) Palette{p};
+    luaL_setmetatable(L, LUA_BLIT_PALETTE);
+}
+
+void lua_blit_pushpalette(lua_State *L, Palette *p) {
+    new(lua_newuserdata(L, sizeof(Palette))) Palette{p->entries};
+    luaL_setmetatable(L, LUA_BLIT_PALETTE);
+}
+
+Palette* lua_blit_checkpalette(lua_State *L, int arg) {
+    auto p = luaL_checkudata(L, arg, LUA_BLIT_PALETTE);
+    return reinterpret_cast<Palette*>(p);
+}
+
+void lua_blit_register_palette(lua_State *L) {
+    lua_register(L, LUA_BLIT_PALETTE, palette_new);
+    luaL_newmetatable(L, LUA_BLIT_PALETTE);
+    lua_pushcfunction(L, palette_delete); lua_setfield(L, -2, "__gc");
+    lua_pushcfunction(L, palette_index); lua_setfield(L, -2, "__index");
+    lua_pushcfunction(L, palette_index); lua_setfield(L, -2, "__newindex");
+}

--- a/lua-bindings/pen.cpp
+++ b/lua-bindings/pen.cpp
@@ -3,13 +3,18 @@
 using namespace blit;
 
 static int pen_new(lua_State* L){
-    int a = 255;
+    uint8_t a = 255;
+    uint8_t r = 0;
+    uint8_t g = 0;
+    uint8_t b = 0;
     int nargs = lua_gettop(L);
-    int r = (int32_t)luaL_checknumber(L, 1);
-    int g = (int32_t)luaL_checknumber(L, 2);
-    int b = (int32_t)luaL_checknumber(L, 3);
-    if(nargs == 4){
-        a = (int32_t)luaL_checknumber(L, 4);
+    if(nargs >= 3){
+        r = (int32_t)luaL_checknumber(L, 1);
+        g = (int32_t)luaL_checknumber(L, 2);
+        b = (int32_t)luaL_checknumber(L, 3);
+    }
+    if(nargs == 4 || nargs == 1){
+        a = (int32_t)luaL_checknumber(L, nargs);
     }
     new(lua_newuserdata(L, sizeof(Pen))) Pen(r, g, b, a);
     luaL_setmetatable(L, LUA_BLIT_PEN);

--- a/lua-bindings/point.cpp
+++ b/lua-bindings/point.cpp
@@ -56,6 +56,26 @@ static int point_add(lua_State *L){
         lua_blit_pushpoint(L, *point_a + *vec_b);
         return 1;
     }
+
+    return 0;
+}
+
+static int point_sub(lua_State *L){
+    Point *point_a = reinterpret_cast<Point*>(lua_touserdata(L, 1));
+
+    auto point_b = reinterpret_cast<Point *>(luaL_testudata(L, 2, LUA_BLIT_POINT));
+    if(point_b) {
+        lua_blit_pushpoint(L, *point_a - *point_b);
+        return 1;
+    }
+
+    auto vec_b = reinterpret_cast<Vec2 *>(luaL_testudata(L, 2, LUA_BLIT_VEC2));
+    if(vec_b) {
+        lua_blit_pushpoint(L, *point_a - *vec_b);
+        return 1;
+    }
+
+    return 0;
 }
 
 static int point_mul(lua_State *L){
@@ -114,6 +134,7 @@ void lua_blit_register_point(lua_State *L) {
     lua_pushcfunction(L, point_index); lua_setfield(L, -2, "__newindex");
 
     lua_pushcfunction(L, point_add); lua_setfield(L, -2, "__add");
+    lua_pushcfunction(L, point_sub); lua_setfield(L, -2, "__sub");
     lua_pushcfunction(L, point_mul); lua_setfield(L, -2, "__mul");
     lua_pushcfunction(L, point_div); lua_setfield(L, -2, "__div");
     lua_pushcfunction(L, point_eq); lua_setfield(L, -2, "__eq");

--- a/lua-bindings/surface.cpp
+++ b/lua-bindings/surface.cpp
@@ -1,0 +1,299 @@
+#include "../luablitlib.hpp"
+
+using namespace blit;
+
+static int surface_clear(lua_State *L) {
+    Surface *surface = reinterpret_cast<Surface*>(lua_touserdata(L, 1));
+    surface->clear();
+    return 0;
+}
+
+static int surface_pixel(lua_State *L) {
+    Surface *surface = reinterpret_cast<Surface*>(lua_touserdata(L, 1));
+    Point *p = lua_blit_checkpoint(L, 2);
+    surface->pixel(*p);
+    return 0;
+}
+
+static int surface_h_span(lua_State *L) {
+    Surface *surface = reinterpret_cast<Surface*>(lua_touserdata(L, 1));
+    Point *p = lua_blit_checkpoint(L, 2);
+    auto c = luaL_checkinteger(L, 3);
+    surface->h_span(*p, c);
+    return 0;
+}
+
+static int surface_v_span(lua_State *L) {
+    Surface *surface = reinterpret_cast<Surface*>(lua_touserdata(L, 1));
+    Point *p = lua_blit_checkpoint(L, 2);
+    auto c = luaL_checkinteger(L, 3);
+    surface->v_span(*p, c);
+    return 0;
+}
+
+static int surface_line(lua_State *L) {
+    Surface *surface = reinterpret_cast<Surface*>(lua_touserdata(L, 1));
+    Point *a = lua_blit_checkpoint(L, 2);
+    Point *b = lua_blit_checkpoint(L, 3);
+    surface->line(*a, *b);
+    return 0;
+}
+
+static int surface_rectangle(lua_State *L) {
+    Surface *surface = reinterpret_cast<Surface*>(lua_touserdata(L, 1));
+    Rect *r = lua_blit_checkrect(L, 2);
+    surface->rectangle(*r);
+    return 0;
+}
+
+static int surface_measure_text(lua_State *L) {
+    Surface *surface = reinterpret_cast<Surface*>(lua_touserdata(L, 1));
+    int nargs = lua_gettop(L);
+    size_t len;
+    auto ptr = luaL_checklstring(L, 2, &len);
+    auto message = std::string_view(ptr, len);
+    auto variable = true;
+
+    // TODO: handle invalid font
+    blit::Font *font = (blit::Font *)lua_touserdata(L, 3);
+
+    if(nargs >= 4) {
+        variable = lua_toboolean(L, 4);
+    }
+
+    auto result = surface->measure_text(message, *font, variable);
+    lua_blit_pushsize(L, result);
+    return 1;
+}
+
+static int surface_wrap_text(lua_State *L) {
+    Surface *surface = reinterpret_cast<Surface*>(lua_touserdata(L, 1));
+    int nargs = lua_gettop(L);
+    size_t len;
+    auto ptr = luaL_checklstring(L, 2, &len);
+    auto message = std::string_view(ptr, len);
+    auto variable = true;
+
+    // TODO: helper
+    auto width = luaL_checkinteger(L, 3);
+
+    // TODO: handle invalid font
+    blit::Font *font = (blit::Font *)lua_touserdata(L, 4);
+
+    if(nargs >= 5) {
+        variable = lua_toboolean(L, 5);
+    }
+
+    std::string text = surface->wrap_text(message, width, *font, variable);
+    lua_pushlstring(L, text.data(), text.length());
+    return 1;
+}
+
+static int surface_text(lua_State *L) {
+    Surface *surface = reinterpret_cast<Surface*>(lua_touserdata(L, 1));
+    auto nargs = lua_gettop(L);
+    size_t len;
+    auto ptr = luaL_checklstring(L, 2, &len);
+    auto message = std::string_view(ptr, len);
+    auto variable = false;
+    auto text_align = TextAlign::top_left;
+
+    // TODO: handle invalid font
+    blit::Font *font = (blit::Font *)lua_touserdata(L, 3);
+
+    if(nargs >= 5) {
+        variable = lua_toboolean(L, 5);
+    }
+
+    if(nargs >= 6) {
+        text_align = static_cast<TextAlign>(luaL_checkinteger(L, 6));
+    }
+
+    // TODO: helper
+    auto point = reinterpret_cast<Point *>(luaL_testudata(L, 4, LUA_BLIT_POINT));
+
+    if(point) {
+        surface->text(message, *font, *point, variable, text_align);
+        return 0;
+    }
+
+    auto rect = reinterpret_cast<Rect *>(luaL_testudata(L, 4, LUA_BLIT_RECT));
+
+    if(rect) {
+        surface->text(message, *font, *rect, variable, text_align);
+        return 0;
+    }
+
+    // error?
+
+    return 0;
+}
+
+static int surface_sprite(lua_State *L) {
+    Surface *surface = reinterpret_cast<Surface*>(lua_touserdata(L, 1));
+    Point *pos = lua_blit_checkpoint(L, 3);
+
+    // (int, point)
+    if(lua_isinteger(L, 2)) {
+        unsigned int i = lua_tointeger(L, 2);
+        surface->sprite(i, *pos);
+        return 0;
+    }
+
+    // (Point, Point)
+    auto p = reinterpret_cast<Point *>(luaL_testudata(L, 2, LUA_BLIT_POINT));
+    if(p) {
+        surface->sprite(*p, *pos);
+        return 0;
+    }
+
+    // (Rect, Point)
+    auto r = reinterpret_cast<Rect *>(luaL_testudata(L, 2, LUA_BLIT_RECT));
+    if(r) {
+        surface->sprite(*r, *pos);
+        return 0;
+    }
+
+    //error?
+
+    return 0;
+}
+
+static int surface_load_sprites(lua_State *L) {
+    Surface *surface = reinterpret_cast<Surface*>(lua_touserdata(L, 1));
+    std::string filename = luaL_checkstring(L, 2);
+    if(surface->sprites != nullptr) {
+        delete surface->sprites->data;
+        delete surface->sprites->palette;
+        delete surface->sprites;
+        surface->sprites = nullptr;
+    }
+    surface->sprites = Surface::load(filename);
+    return 0;
+}
+
+static int surface_blit(lua_State *L) {
+    Surface *surface = reinterpret_cast<Surface*>(lua_touserdata(L, 1));
+    int nargs = lua_gettop(L);
+    bool hflip = false;
+    if(nargs >= 5) {
+        hflip = lua_toboolean(L, 5);
+    }
+    auto source_surface = lua_blit_checksurface(L, 2);
+    auto source_rect = lua_blit_checkrect(L, 3);
+    auto dest_point = lua_blit_checkpoint(L, 4);
+    surface->blit(source_surface, *source_rect, *dest_point, hflip);
+    return 0;
+}
+
+static int surface_stretch_blit(lua_State *L) {
+    Surface *surface = reinterpret_cast<Surface*>(lua_touserdata(L, 1));
+    auto source_surface = lua_blit_checksurface(L, 2);
+    auto source_rect = lua_blit_checkrect(L, 3);
+    auto dest_rect = lua_blit_checkrect(L, 4);
+    surface->stretch_blit(source_surface, *source_rect, *dest_rect);
+    return 0;
+}
+
+static int surface_new(lua_State* L){
+    int nargs = lua_gettop(L);
+    auto pixel_format = PixelFormat::RGBA;
+    auto bounds = lua_blit_checksize(L, 1);
+
+    if(nargs >= 2) {
+        pixel_format = static_cast<PixelFormat>(luaL_checkinteger(L, 2));
+    }
+
+    uint8_t *data = new uint8_t[bounds->w * bounds->h * pixel_format_stride[static_cast<uint8_t>(pixel_format)]];
+    new(lua_newuserdata(L, sizeof(Surface))) Surface(data, pixel_format, *bounds);
+    luaL_setmetatable(L, LUA_BLIT_SURFACE);
+    return 1;
+}
+
+static int surface_delete(lua_State* L){
+    Surface *surface = reinterpret_cast<Surface*>(lua_touserdata(L, 1));
+    if(surface->sprites != nullptr) {
+        delete surface->sprites->data;
+        delete surface->sprites->palette;
+        delete surface->sprites;
+        surface->sprites = nullptr;
+    }
+    delete surface->data;
+    delete surface;
+    return 0;
+}
+
+static int surface_index(lua_State* L){
+    int nargs = lua_gettop(L);
+    Surface *surface = reinterpret_cast<Surface*>(lua_touserdata(L, 1));
+    std::string_view method = luaL_checkstring(L, 2);
+
+    if(method == "pixel") {lua_pushcfunction(L, surface_pixel); return 1;}
+    if(method == "h_span") {lua_pushcfunction(L, surface_h_span); return 1;}
+    if(method == "v_span") {lua_pushcfunction(L, surface_v_span); return 1;}
+    if(method == "line") {lua_pushcfunction(L, surface_line); return 1;}
+    if(method == "rectangle") {lua_pushcfunction(L, surface_rectangle); return 1;}
+    if(method == "text") {lua_pushcfunction(L, surface_text); return 1;}
+    if(method == "wrap_text") {lua_pushcfunction(L, surface_wrap_text); return 1;}
+    if(method == "measure_text") {lua_pushcfunction(L, surface_measure_text); return 1;}
+    if(method == "clear") {lua_pushcfunction(L, surface_clear); return 1;}
+    if(method == "load_sprites") {lua_pushcfunction(L, surface_load_sprites); return 1;}
+    if(method == "sprite") {lua_pushcfunction(L, surface_sprite); return 1;}
+    if(method == "blit") {lua_pushcfunction(L, surface_blit); return 1;}
+    if(method == "stretch_blit") {lua_pushcfunction(L, surface_stretch_blit); return 1;}
+
+    if(nargs == 3) {
+        if(method == "pen") {
+            Pen *p = lua_blit_checkpen(L, 3);
+            surface->pen = *p;
+            return 0;
+        }
+        if(method == "clip") {
+            Rect *r = lua_blit_checkrect(L, 3);
+            surface->clip = *r;
+            return 0;
+        }
+        if(method == "alpha") {
+            surface->alpha = luaL_checkinteger(L, 3);
+            return 0;
+        }
+        if(surface->format == PixelFormat::P && method == "palette") {
+            auto palette = lua_blit_checkpalette(L, 3);
+            surface->palette = palette->entries;
+            return 0;
+        }
+    } else {
+        if(method == "bounds") {lua_blit_pushsize(L, surface->bounds); return 1;}
+        if(method == "pen") {lua_blit_pushpen(L, surface->pen); return 1;}
+        if(method == "alpha") {lua_pushinteger(L, surface->alpha); return 1;}
+        if(surface->format == PixelFormat::P && method == "palette") {
+            if(!surface->palette) {
+                surface->palette = new Pen[256];
+            }
+            lua_blit_pushpalette(L, surface->palette);
+            return 1;
+        }
+    }
+
+    luaL_error(L, "Unknown property or method `%s` on %s", method.data(), LUA_BLIT_SURFACE);
+    return 0;
+}
+
+void lua_blit_pushsurface(lua_State* L, Surface s) {
+    new(lua_newuserdata(L, sizeof(Surface))) Surface(s);
+    luaL_setmetatable(L, LUA_BLIT_SURFACE);
+}
+
+Surface* lua_blit_checksurface(lua_State *L, int arg) {
+    auto t = luaL_checkudata(L, arg, LUA_BLIT_SURFACE);
+    return reinterpret_cast<Surface*>(t);
+}
+
+void lua_blit_register_surface(lua_State *L) {
+    lua_register(L, LUA_BLIT_SURFACE, surface_new);
+    luaL_newmetatable(L, LUA_BLIT_SURFACE);
+    lua_pushcfunction(L, surface_delete); lua_setfield(L, -2, "__gc");
+    lua_pushcfunction(L, surface_index); lua_setfield(L, -2, "__index");
+    lua_pushcfunction(L, surface_index); lua_setfield(L, -2, "__newindex");
+    lua_pop(L, 1);
+}

--- a/luablitlib.cpp
+++ b/luablitlib.cpp
@@ -86,6 +86,8 @@ void lua_blit_setup_globals (lua_State *L) {
     lua_blit_register_rect(L);
     //lua_blit_register_sprites(L);
     lua_blit_register_timer(L);
+    lua_blit_register_palette(L);
+    lua_blit_register_surface(L);
 
     // And fonts, too
     lua_pushlightuserdata(L, (void *)(&minimal_font));
@@ -104,6 +106,18 @@ void lua_blit_setup_globals (lua_State *L) {
         lua_pushnumber(L, ScreenMode::hires_palette);
         lua_setfield(L, -2, "hires_palette");
     lua_setglobal(L, "ScreenMode");
+
+    // PixelFormat enum
+    lua_newtable(L);
+        lua_pushnumber(L, static_cast<uint8_t>(PixelFormat::M));
+        lua_setfield(L, -2, "M");
+        lua_pushnumber(L, static_cast<uint8_t>(PixelFormat::P));
+        lua_setfield(L, -2, "P");
+        lua_pushnumber(L, static_cast<uint8_t>(PixelFormat::RGB));
+        lua_setfield(L, -2, "RGB");
+        lua_pushnumber(L, static_cast<uint8_t>(PixelFormat::RGBA));
+        lua_setfield(L, -2, "RGBA");
+    lua_setglobal(L, "PixelFormat");
 
     // Button enum
     lua_newtable(L);

--- a/luablitlib.hpp
+++ b/luablitlib.hpp
@@ -14,6 +14,8 @@
 #define LUA_BLIT_SIZE "Size"
 #define LUA_BLIT_RECT "Rect"
 #define LUA_BLIT_TIMER "Timer"
+#define LUA_BLIT_SURFACE "Surface"
+#define LUA_BLIT_PALETTE "Palette"
 
 LUAMOD_API int luaopen_blit (lua_State *L);
 void lua_blit_setup_globals (lua_State *L);
@@ -46,3 +48,15 @@ void lua_blit_pushrect(lua_State* L, blit::Rect p);
 blit::Rect* lua_blit_checkrect(lua_State *L, int arg);
 
 void lua_blit_register_timer(lua_State *L);
+
+struct Palette {
+    blit::Pen *entries;
+};
+void lua_blit_register_palette(lua_State *L);
+void lua_blit_pushpalette(lua_State* L, Palette *p);
+void lua_blit_pushpalette(lua_State* L, blit::Pen *p);
+Palette* lua_blit_checkpalette(lua_State *L, int arg);
+
+void lua_blit_register_surface(lua_State *L);
+void lua_blit_pushsurface(lua_State* L, blit::Surface s);
+blit::Surface* lua_blit_checksurface(lua_State *L, int arg);


### PR DESCRIPTION
Allows a Surface to be created, drawn into and blit to the screen or another Surface.

Surfaces can be RGB, RGBA, M or P mode.

P mode surface palettes can be set with: surface.palette[index] = Pen()
Or swapped entirely with: surface.palette = Palette()