### PR TITLE
Refactor buttons/joystick/tilt input state update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ set(PROJECT_SOURCE
   lua-bindings/timer.cpp
   lua-bindings/palette.cpp
   lua-bindings/surface.cpp
+  lua-bindings/input.cpp
   lua-bindings/screen.cpp)
 
 set(PROJECT_DISTRIBS

--- a/examples/input.lua
+++ b/examples/input.lua
@@ -1,0 +1,110 @@
+function init()
+    set_screen_mode(ScreenMode.hires)
+    -- Start the cursor in the middle of the screen
+    cursor = Vec2(screen.bounds.w / 2, screen.bounds.h / 2)
+end
+
+function update(time)
+    button_a_colour = Pen(100, 0, 100)
+    button_b_colour = Pen(100, 100, 0)
+    button_x_colour = Pen(0, 0, 100)
+    button_y_colour = Pen(0, 100, 0)
+    if input.state.A then
+        button_a_colour = Pen(255, 0, 255)
+    end
+    if input.state.B then
+        button_b_colour = Pen(255, 255, 0)
+    end
+    if input.state.X then
+        button_x_colour = Pen(0, 0, 255)
+    end
+    if input.state.Y then
+        button_y_colour = Pen(0, 255, 0)
+    end
+
+    dpad_u_colour = Pen(100, 100, 100)
+    dpad_d_colour = Pen(100, 100, 100)
+    dpad_l_colour = Pen(100, 100, 100)
+    dpad_r_colour = Pen(100, 100, 100)
+    if input.state.UP then
+        dpad_u_colour = Pen(200, 200, 200)
+    end
+    if input.state.DOWN then
+        dpad_d_colour = Pen(200, 200, 200)
+    end
+    if input.state.LEFT then
+        dpad_l_colour = Pen(200, 200, 200)
+    end
+    if input.state.RIGHT then
+        dpad_r_colour = Pen(200, 200, 200)
+    end
+
+    -- Update cursor position from joystick
+    cursor = cursor + (joystick * 2.0)
+    cursor.x = math.max(0, math.min(screen.bounds.w, cursor.x))
+    cursor.y = math.max(0, math.min(screen.bounds.h, cursor.y))
+end
+
+function render(time)
+    screen.pen = Pen(0, 0, 0)
+    screen.clear()
+    
+    dpad_center = Point(screen.bounds.w / 4, screen.bounds.h / 2)
+    buttons_center = Point((screen.bounds.w / 4) * 3, screen.bounds.h / 2)
+
+
+    -- Draw the cross-shaped D-Pad
+    dpad = Rect(0, 0, 120, 40)
+    dpad.x = dpad_center.x - (dpad.w / 2)
+    dpad.y = dpad_center.y - (dpad.h / 2)
+    screen.pen = Pen(100, 100, 100)
+    screen.rectangle(dpad)
+
+    dpad_direction = Rect(0, 0, 40, 40)
+
+    dpad_direction.x = dpad.tl.x
+    dpad_direction.y = dpad.tl.y
+    screen.pen = dpad_l_colour
+    screen.rectangle(dpad_direction)
+
+    dpad_direction.x = dpad.tr.x - dpad_direction.w
+    dpad_direction.y = dpad.tr.y
+    screen.pen = dpad_r_colour
+    screen.rectangle(dpad_direction)
+
+    dpad.w, dpad.h = dpad.h, dpad.w -- Swap the width/height, effectively a 90 degree rotation
+    dpad.x = dpad_center.x - (dpad.w / 2)
+    dpad.y = dpad_center.y - (dpad.h / 2)
+    screen.pen = Pen(100, 100, 100)
+    screen.rectangle(dpad)
+
+    dpad_direction.x = dpad.tl.x
+    dpad_direction.y = dpad.tl.y
+    screen.pen = dpad_u_colour
+    screen.rectangle(dpad_direction)
+
+    dpad_direction.x = dpad.bl.x
+    dpad_direction.y = dpad.bl.y - dpad_direction.h
+    screen.pen = dpad_d_colour
+    screen.rectangle(dpad_direction)
+
+    -- Draw the 4 face buttons
+    button_distance = 40 -- Distance each button circle should be from the middle
+    button_size = 20 -- Radius of the button circles
+    
+    screen.pen = button_y_colour
+    screen.circle(buttons_center + Point(-button_distance, 0), button_size)
+
+    screen.pen = button_a_colour
+    screen.circle(buttons_center + Point(button_distance, 0), button_size)
+
+    screen.pen = button_x_colour
+    screen.circle(buttons_center + Point(0, -button_distance), button_size)
+
+    screen.pen = button_b_colour
+    screen.circle(buttons_center + Point(0, button_distance), button_size)
+
+    -- Draw the joystick cursor
+    screen.pen = Pen(255, 0, 0)
+    screen.circle(Point(cursor.x, cursor.y), 3)
+end

--- a/examples/input.lua
+++ b/examples/input.lua
@@ -9,16 +9,16 @@ function update(time)
     button_b_colour = Pen(100, 100, 0)
     button_x_colour = Pen(0, 0, 100)
     button_y_colour = Pen(0, 100, 0)
-    if input.state.A then
+    if buttons.state & Button.A ~= 0 then
         button_a_colour = Pen(255, 0, 255)
     end
-    if input.state.B then
+    if buttons.state & Button.B ~= 0 then
         button_b_colour = Pen(255, 255, 0)
     end
-    if input.state.X then
+    if buttons.state & Button.X ~= 0 then
         button_x_colour = Pen(0, 0, 255)
     end
-    if input.state.Y then
+    if buttons.state & Button.Y ~= 0 then
         button_y_colour = Pen(0, 255, 0)
     end
 
@@ -26,16 +26,16 @@ function update(time)
     dpad_d_colour = Pen(100, 100, 100)
     dpad_l_colour = Pen(100, 100, 100)
     dpad_r_colour = Pen(100, 100, 100)
-    if input.state.UP then
+    if buttons.state & Button.UP ~= 0 then
         dpad_u_colour = Pen(200, 200, 200)
     end
-    if input.state.DOWN then
+    if buttons.state & Button.DOWN ~= 0 then
         dpad_d_colour = Pen(200, 200, 200)
     end
-    if input.state.LEFT then
+    if buttons.state & Button.LEFT ~= 0 then
         dpad_l_colour = Pen(200, 200, 200)
     end
-    if input.state.RIGHT then
+    if buttons.state & Button.RIGHT ~= 0 then
         dpad_r_colour = Pen(200, 200, 200)
     end
 

--- a/lua-bindings/input.cpp
+++ b/lua-bindings/input.cpp
@@ -1,0 +1,66 @@
+#include "../luablitlib.hpp"
+
+using namespace blit;
+
+void input_table(lua_State *L, uint32_t input) {
+    lua_newtable(L);
+    lua_pushboolean(L, input & Button::A);
+    lua_setfield(L, -2, "A");
+    lua_pushboolean(L, input & Button::B);
+    lua_setfield(L, -2, "B");
+    lua_pushboolean(L, input & Button::X);
+    lua_setfield(L, -2, "X");
+    lua_pushboolean(L, input & Button::Y);
+    lua_setfield(L, -2, "Y");
+
+    lua_pushboolean(L, input & Button::DPAD_UP);
+    lua_setfield(L, -2, "UP");
+    lua_pushboolean(L, input & Button::DPAD_DOWN);
+    lua_setfield(L, -2, "DOWN");
+    lua_pushboolean(L, input & Button::DPAD_LEFT);
+    lua_setfield(L, -2, "LEFT");
+    lua_pushboolean(L, input & Button::DPAD_RIGHT);
+    lua_setfield(L, -2, "RIGHT");
+}
+
+static int input_index(lua_State* L){
+    int nargs = lua_gettop(L);
+    std::string_view method = luaL_checkstring(L, 2);
+
+    if(method == "joystick") {lua_blit_pushvec2(L, joystick); return 1;}
+    if(method == "tilt") {lua_blit_pushvec3(L, tilt); return 1;}
+    if(method == "state") {
+        input_table(L, buttons.state);
+        return 1;
+    }
+    if(method == "pressed") {
+        input_table(L, buttons.pressed);
+        return 1;
+    }
+    if(method == "released") {
+        input_table(L, buttons.released);
+        return 1;
+    }
+
+    luaL_error(L, "Unknown property or method `%s` on %s", std::string(method).c_str(), "input");
+    return 0;
+}
+
+static const luaL_Reg input_funcs[] = {
+    {NULL, NULL}
+};
+
+static const luaL_Reg screen_meta_funcs[] = {
+    {"__index", input_index},
+    {"__newindex", input_index},
+    {NULL, NULL}
+};
+
+void lua_blit_setup_input(lua_State *L) {
+    luaL_newmetatable(L, "input");
+    lua_pushvalue(L, -1);
+    luaL_setfuncs(L, input_funcs, 0);
+    luaL_newlib(L, screen_meta_funcs);
+    lua_setmetatable(L, -2);
+    lua_setglobal(L, "input");
+}

--- a/lua-bindings/input.cpp
+++ b/lua-bindings/input.cpp
@@ -5,46 +5,15 @@ using namespace blit;
 Vec2* ud_joystick;
 Vec3 *ud_tilt;
 
-void input_state_table(lua_State *L, uint32_t input) {
-    lua_pushboolean(L, input & Button::A);
-    lua_setfield(L, -2, "A");
-    lua_pushboolean(L, input & Button::B);
-    lua_setfield(L, -2, "B");
-    lua_pushboolean(L, input & Button::X);
-    lua_setfield(L, -2, "X");
-    lua_pushboolean(L, input & Button::Y);
-    lua_setfield(L, -2, "Y");
-
-    lua_pushboolean(L, input & Button::DPAD_UP);
-    lua_setfield(L, -2, "UP");
-    lua_pushboolean(L, input & Button::DPAD_DOWN);
-    lua_setfield(L, -2, "DOWN");
-    lua_pushboolean(L, input & Button::DPAD_LEFT);
-    lua_setfield(L, -2, "LEFT");
-    lua_pushboolean(L, input & Button::DPAD_RIGHT);
-    lua_setfield(L, -2, "RIGHT");
-
-    lua_pushboolean(L, input & Button::HOME);
-    lua_setfield(L, -2, "HOME");
-    lua_pushboolean(L, input & Button::MENU);
-    lua_setfield(L, -2, "MENU");
-
-    lua_pushboolean(L, input & Button::JOYSTICK);
-    lua_setfield(L, -2, "JOYSTICK");
-}
-
 void lua_blit_setup_input(lua_State *L) {
     lua_newtable(L);
-    lua_setglobal(L, "buttons");
-
-    lua_newtable(L);
-        lua_newtable(L);
+        lua_pushinteger(L, buttons.pressed);
         lua_setfield(L, -2, "pressed");
-        lua_newtable(L);
+        lua_pushinteger(L, buttons.released);
         lua_setfield(L, -2, "released");
-        lua_newtable(L);
+        lua_pushinteger(L, buttons.state);
         lua_setfield(L, -2, "state");
-    lua_setglobal(L, "input");
+    lua_setglobal(L, "buttons");
 
     ud_joystick = new(lua_newuserdata(L, sizeof(Vec2))) Vec2(joystick);
     luaL_setmetatable(L, LUA_BLIT_VEC2);
@@ -65,21 +34,7 @@ void lua_blit_update_input(lua_State *L) {
         lua_setfield(L, -2, "released");
         lua_pushinteger(L, buttons.state);
         lua_setfield(L, -2, "state");
-    lua_setglobal(L, "buttons");
-
-    lua_getglobal(L, "input");
-        lua_getfield(L, -1, "pressed");
-        input_state_table(L, buttons.pressed);
-        lua_setfield(L, -2, "pressed");
-
-        lua_getfield(L, -1, "released");
-        input_state_table(L, buttons.released);
-        lua_setfield(L, -2, "released");
-
-        lua_getfield(L, -1, "state");
-        input_state_table(L, buttons.state);
-        lua_setfield(L, -2, "state");
-    lua_setglobal(L, "input");
+    lua_pop(L, 1);
 
     *ud_joystick = joystick;
     *ud_tilt = tilt;

--- a/lua-bindings/input.cpp
+++ b/lua-bindings/input.cpp
@@ -2,6 +2,9 @@
 
 using namespace blit;
 
+Vec2* ud_joystick;
+Vec3 *ud_tilt;
+
 void input_state_table(lua_State *L, uint32_t input) {
     lua_pushboolean(L, input & Button::A);
     lua_setfield(L, -2, "A");
@@ -42,6 +45,14 @@ void lua_blit_setup_input(lua_State *L) {
         lua_newtable(L);
         lua_setfield(L, -2, "state");
     lua_setglobal(L, "input");
+
+    ud_joystick = new(lua_newuserdata(L, sizeof(Vec2))) Vec2(joystick);
+    luaL_setmetatable(L, LUA_BLIT_VEC2);
+    lua_setglobal(L, "joystick");
+
+    ud_tilt = new(lua_newuserdata(L, sizeof(Vec3))) Vec3(tilt);
+    luaL_setmetatable(L, LUA_BLIT_VEC3);
+    lua_setglobal(L, "tilt");
 }
 
 void lua_blit_update_input(lua_State *L) {
@@ -70,11 +81,6 @@ void lua_blit_update_input(lua_State *L) {
         lua_setfield(L, -2, "state");
     lua_setglobal(L, "input");
 
-    new(lua_newuserdata(L, sizeof(Vec2))) Vec2(joystick);
-    luaL_setmetatable(L, LUA_BLIT_VEC2);
-    lua_setglobal(L, "joystick");
-
-    new(lua_newuserdata(L, sizeof(Vec3))) Vec3(tilt);
-    luaL_setmetatable(L, LUA_BLIT_VEC3);
-    lua_setglobal(L, "tilt");
+    *ud_joystick = joystick;
+    *ud_tilt = tilt;
 }

--- a/lua-bindings/point.cpp
+++ b/lua-bindings/point.cpp
@@ -7,7 +7,7 @@ static int point_new(lua_State* L){
     int32_t x = 0;
     int32_t y = 0;
     if(nargs == 1) {
-        Point *vec = lua_blit_checkpoint(L, 1);
+        Vec2 *vec = lua_blit_checkvec2(L, 1);
         x = (int32_t)vec->x;
         y = (int32_t)vec->y;
     }

--- a/lua-bindings/vec2.cpp
+++ b/lua-bindings/vec2.cpp
@@ -89,8 +89,23 @@ static int vec2_add(lua_State *L){
 
 static int vec2_mul(lua_State *L){
     Vec2 *vec2_a = reinterpret_cast<Vec2*>(lua_touserdata(L, 1));
-    Vec2 *vec2_b = reinterpret_cast<Vec2*>(lua_touserdata(L, 2));
-    lua_blit_pushvec2(L, *vec2_a * *vec2_b);
+    float f_b;
+    Vec2 *vec2_b;
+    
+    switch(lua_type(L, 2)) {
+        case LUA_TNUMBER:
+            f_b = lua_tonumber(L, 2);
+            lua_blit_pushvec2(L, *vec2_a * f_b);
+            return 1;
+            break;
+        case LUA_TUSERDATA:
+            vec2_b = reinterpret_cast<Vec2*>(lua_touserdata(L, 2));
+            lua_blit_pushvec2(L, *vec2_a * *vec2_b);
+            return 1;
+            break;
+    }
+    
+    lua_blit_pushvec2(L, *vec2_a);
     return 1;
 }
 

--- a/luablitlib.cpp
+++ b/luablitlib.cpp
@@ -43,24 +43,7 @@ static int hsv_to_rgba(lua_State *L) {
 }
 
 void lua_blit_update_state(lua_State *L) {
-    // use "buttons.pressed & Button.RIGHT ~= 0"
-
-    lua_newtable(L);
-        lua_pushinteger(L, buttons.pressed);
-        lua_setfield(L, -2, "pressed");
-        lua_pushinteger(L, buttons.released);
-        lua_setfield(L, -2, "released");
-        lua_pushinteger(L, buttons.state);
-        lua_setfield(L, -2, "state");
-    lua_setglobal(L, "buttons");
-
-    new(lua_newuserdata(L, sizeof(Vec2))) Vec2(joystick);
-    luaL_setmetatable(L, LUA_BLIT_VEC2);
-    lua_setglobal(L, "joystick");
-
-    new(lua_newuserdata(L, sizeof(Vec3))) Vec3(tilt);
-    luaL_setmetatable(L, LUA_BLIT_VEC3);
-    lua_setglobal(L, "tilt");
+    lua_blit_update_input(L);
 }
 
 static const luaL_Reg blit_funcs[] = {

--- a/luablitlib.cpp
+++ b/luablitlib.cpp
@@ -60,7 +60,6 @@ LUAMOD_API int luaopen_blit (lua_State *L) {
 
 void lua_blit_setup_globals (lua_State *L) {
     lua_blit_setup_screen(L);
-    lua_blit_setup_input(L);
 
     // We'll allow all basic types in the global namespace
     lua_blit_register_point(L);
@@ -72,6 +71,8 @@ void lua_blit_setup_globals (lua_State *L) {
     lua_blit_register_timer(L);
     lua_blit_register_palette(L);
     lua_blit_register_surface(L);
+
+    lua_blit_setup_input(L);
 
     // And fonts, too
     lua_pushlightuserdata(L, (void *)(&minimal_font));

--- a/luablitlib.cpp
+++ b/luablitlib.cpp
@@ -77,6 +77,7 @@ LUAMOD_API int luaopen_blit (lua_State *L) {
 
 void lua_blit_setup_globals (lua_State *L) {
     lua_blit_setup_screen(L);
+    lua_blit_setup_input(L);
 
     // We'll allow all basic types in the global namespace
     lua_blit_register_point(L);

--- a/luablitlib.hpp
+++ b/luablitlib.hpp
@@ -21,8 +21,10 @@ LUAMOD_API int luaopen_blit (lua_State *L);
 void lua_blit_setup_globals (lua_State *L);
 void lua_blit_update_state(lua_State *L);
 
-void lua_blit_setup_screen (lua_State *L);
+void lua_blit_setup_screen(lua_State *L);
+
 void lua_blit_setup_input(lua_State *L);
+void lua_blit_update_input(lua_State *L);
 
 void lua_blit_register_point(lua_State *L);
 void lua_blit_pushpoint(lua_State* L, blit::Point p);

--- a/luablitlib.hpp
+++ b/luablitlib.hpp
@@ -22,6 +22,7 @@ void lua_blit_setup_globals (lua_State *L);
 void lua_blit_update_state(lua_State *L);
 
 void lua_blit_setup_screen (lua_State *L);
+void lua_blit_setup_input(lua_State *L);
 
 void lua_blit_register_point(lua_State *L);
 void lua_blit_pushpoint(lua_State* L, blit::Point p);


### PR DESCRIPTION
This PR aims to replace the constant creation of new tables/userdata for button input, joystick and tilt with a single creation, followed by in-place updates of the table values and userdata's underlying `Vec2` and `Vec3`. This should - in theory - produce less busywork for garbage collection on every `update` call, since instead of replacing the `joystick` and `tilt` userdata with new objects, this just updates their values.

Similarly for buttons a `button` table is created in `lua_blit_setup_input` and then loaded and mutated in `lua_blit_update_input`. You can `print(buttons)` to observe that the address of the buttons table no longer updates on each `render`.

## Original musings for posterity:

Adds a new experimental `input` table that sweeps the somewhat verbose bit-test input handling under the rug in favour of exposing a boolean for each button.

This:

```lua
if buttons.state & Button.UP ~= 0 then
end
if buttons.state & Button.DOWN ~= 0 then
end
if buttons.state & Button.LEFT ~= 0 then
end
if buttons.state & Button.RIGHT ~= 0 then
end
```

Becomes this:

```lua
if input.state.UP then
end
if input.state.DOWN then
end
if input.state.LEFT then
end
if input.state.RIGHT then
end
```

While this *looks* like it might also be faster, every use of `input.state`, `input.pressed` or `input.released` invokes an on-the-fly construction of a Lua table with the current values:

```c++
void input_table(lua_State *L, uint32_t input) {
    lua_newtable(L);
    lua_pushboolean(L, input & Button::A);
    lua_setfield(L, -2, "A");
    lua_pushboolean(L, input & Button::B);
    lua_setfield(L, -2, "B");
    lua_pushboolean(L, input & Button::X);
    lua_setfield(L, -2, "X");
    lua_pushboolean(L, input & Button::Y);
    lua_setfield(L, -2, "Y");

    lua_pushboolean(L, input & Button::DPAD_UP);
    lua_setfield(L, -2, "UP");
    lua_pushboolean(L, input & Button::DPAD_DOWN);
    lua_setfield(L, -2, "DOWN");
    lua_pushboolean(L, input & Button::DPAD_LEFT);
    lua_setfield(L, -2, "LEFT");
    lua_pushboolean(L, input & Button::DPAD_RIGHT);
    lua_setfield(L, -2, "RIGHT");
}
```

That's a lot of heavy lifting just to test a bool. The bit check approach pushes a new table into Lua before calling `update` so this same cost could be paid *one* per update instead of once per button test.

TODO: rework this to push the same table structure *once* and update it before each call to `update`