### PR TITLE
Move Lua VM to ITCM RAM

### DIFF
--- a/lua/CMakeLists.txt
+++ b/lua/CMakeLists.txt
@@ -37,7 +37,8 @@ add_library(lua STATIC
     wrap/stdio.cpp
 )
 
+target_include_directories(lua PRIVATE ${32BLIT_DIR}/32blit)
+
 if(32BLIT_HW)
     target_include_directories(lua SYSTEM PUBLIC wrap)
-    target_include_directories(lua PRIVATE ${32BLIT_DIR}/32blit)
 endif()

--- a/lua/lvm.c
+++ b/lua/lvm.c
@@ -30,6 +30,7 @@
 #include "ltm.h"
 #include "lvm.h"
 
+#include "engine/fast_code.hpp"
 
 /*
 ** By default, use jump tables in the main interpreter loop on gcc
@@ -1118,8 +1119,7 @@ void luaV_finishOp (lua_State *L) {
 #define vmcase(l)	case l:
 #define vmbreak		break
 
-
-void luaV_execute (lua_State *L, CallInfo *ci) {
+void blit_fast_code(luaV_execute) (lua_State *L, CallInfo *ci) {
   LClosure *cl;
   TValue *k;
   StkId base;


### PR DESCRIPTION
Take advantage of the new ITCM RAM support to dramatically speed up the Lua VM.

See: https://github.com/32blit/32blit-sdk/pull/737