### PR TITLE
Fix exception handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@ set(PROJECT_SOURCE
   lua-bindings/input.cpp
   lua-bindings/screen.cpp)
 
+if(32BLIT_HW)
+  list(APPEND PROJECT_SOURCE setjmp.c)
+endif()
+
 set(PROJECT_DISTRIBS
     LICENSE
     README.md)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,11 @@ set(PROJECT_EXAMPLES ${CMAKE_CURRENT_LIST_DIR}/examples)
 
 # Build configuration; approach this with caution!
 if(MSVC)
-  add_compile_options("/W4" "/wd4244" "/wd4324")
+  add_compile_options("/W4" "/wd4244" "/wd4324" "/wd4458" "/wd4100")
 else()
-  add_compile_options("-Wall" "-Wextra" "-Wdouble-promotion")
+  add_compile_options("-Wall" "-Wextra" "-Wdouble-promotion" "-Wno-unused-parameter")
 endif()
+
 find_package(32BLIT CONFIG REQUIRED PATHS ../ /opt)
 
 blit_executable (${PROJECT_NAME} ${PROJECT_SOURCE})

--- a/lua/luaconf.h
+++ b/lua/luaconf.h
@@ -753,8 +753,19 @@
 ** without modifying the main part of the file.
 */
 
+#ifdef TARGET_32BLIT_HW
+int fp_setjmp(int *regs);
+int fp_longjmp(int *regs);
 
+struct fp_jmp_buf
+{
+    int regs[10 + 16];
+};
 
+#define LUAI_THROW(L,c) fp_longjmp((c)->b.regs)
+#define LUAI_TRY(L,c,a)	if (fp_setjmp((c)->b.regs) == 0) { a }
+#define luai_jmpbuf     struct fp_jmp_buf
+#endif
 
 
 #endif

--- a/setjmp.c
+++ b/setjmp.c
@@ -1,0 +1,24 @@
+// newlib's setjmp/longjmp don't save/restore ploating point registers
+// these do
+int fp_setjmp(int *regs) {
+    asm volatile (
+        "stmia r0!, {r4-r11}\n"
+        "mov r1, sp\n"
+        "mov r2, lr\n"
+        "stmia r0!, {r1-r2}\n"
+        "vstmia r0, {d8-d15}"
+    );
+    return 0;
+}
+
+int fp_longjmp(int *regs) {
+    asm volatile (
+        "ldmia r0!, {r4-r11}\n"
+        "ldmia r0!, {r1-r2}\n"
+        "mov sp, r1\n"
+        "mov lr, r2\n"
+        "vldmia r0, {d8-d15}\n"
+    );
+    return 1;
+}
+


### PR DESCRIPTION
This fixes a issue that results in the backlight getting disabled with some firmware builds and a lua script containing an error.

More explanation to make that sound less absurd:
- `lua_pcall` /`lua_error` use `setjmp`/`longjmp`
- newlib's `setjmp`/`longjmp` don't save/restore floating point regs
- `sleep_fade` in the firmware is a float
- incorrect float registers break sleep updates (ends up removing the clamp to 1.0)
- out of bounds `sleep_fade` results in invalid PWM values for backlight
- ~~/me gets very confused and spends ages debugging~~

So here's some custom exception handling that saves more registers and seems to work...