### PR TITLE
Improve error handling

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -60,7 +60,12 @@ void init() {
 }
 
 void render(uint32_t time) {
-    if(!has_render) return;
+    if(!has_render) {
+        blit::screen.pen = {0, 0, 0};
+        blit::screen.clear();
+        return;
+    }
+
     uint32_t ms_start = now();
     lua_getglobal(L, "render");
     lua_pushnumber(L, time);

--- a/main.cpp
+++ b/main.cpp
@@ -23,7 +23,13 @@ void init() {
     if(!launchPath) {
         launchPath = "main.lua";
     }
-    luaL_loadfile(L, launchPath);
+    auto err = luaL_loadfile(L, launchPath);
+
+    if(err) {
+        blit::debugf("Error loading %s: %s\n", launchPath, lua_tostring(L, -1));
+        has_render = has_update = false;
+        return;
+    }
 
     // Super important priming call that makes stuff not explode
     if(lua_pcall(L, 0, 0, 0) != 0){


### PR DESCRIPTION
Getting the error message when a file fails to load instead of "attempt to call a string value" because we tried to _execute the error message_ is... more useful. Also not flashing random junk is nice.

(Yeah, I know... TWO lua PRs at once. How unexpected.)