### PR TITLE
"Fix" actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
 
           - os: macos-latest
             name: macOS
-            release-suffix: MACOS
+            #release-suffix: MACOS
             cmake-args: -D32BLIT_DIR=$GITHUB_WORKSPACE/32blit-sdk
             brew-packages: sdl2 sdl2_image sdl2_net pipx
 
@@ -106,18 +106,21 @@ jobs:
 
     # When it's a release, generate tar/zip files of the build
     - name: Package Release
+      if: matrix.release-suffix != ''
       shell: bash
       working-directory: ${{runner.workspace}}/main/build
       run: |
         cmake --build . --config $BUILD_TYPE --target package
 
     - name: Tar artifact
+      if: matrix.release-suffix != ''
       uses: actions/upload-artifact@v3
       with:
         name: ${{env.RELEASE_FILE}}.tar.gz
         path: ${{runner.workspace}}/main/build/${{env.RELEASE_FILE}}.tar.gz
 
     - name: Zip artifact
+      if: matrix.release-suffix != ''
       uses: actions/upload-artifact@v3
       with:
         path: ${{runner.workspace}}/main/build/${{env.RELEASE_FILE}}.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
             name: macOS
             release-suffix: MACOS
             cmake-args: -D32BLIT_DIR=$GITHUB_WORKSPACE/32blit-sdk
-            brew-packages: sdl2 sdl2_image sdl2_net
+            brew-packages: sdl2 sdl2_image sdl2_net pipx
 
           - os: windows-latest
             name: Visual Studio
@@ -78,7 +78,7 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         brew install ${{matrix.brew-packages}}
-        python3 -m pip install 32blit
+        pipx install 32blit
 
     # Windows dependencies
     - name: Install Windows deps


### PR DESCRIPTION
Fix macOS build (python), but disable the releases/artefacts as `fixup_bundle` is failing again.

```
 CMake Error at /opt/homebrew/Cellar/cmake/3.30.3/share/cmake/Modules/BundleUtilities.cmake:458 (message):
  otool -l failed: 1

  error:
  /Applications/Xcode_15.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/otool-classic:
  can't open file: @rpath/libjxl_cms.0.10.dylib (No such file or directory)

Call Stack (most recent call first):
  /opt/homebrew/Cellar/cmake/3.30.3/share/cmake/Modules/BundleUtilities.cmake:527 (get_item_rpaths)
  /opt/homebrew/Cellar/cmake/3.30.3/share/cmake/Modules/BundleUtilities.cmake:649 (set_bundle_key_values)
  /opt/homebrew/Cellar/cmake/3.30.3/share/cmake/Modules/BundleUtilities.cmake:933 (get_bundle_keys)
  /Users/runner/work/32blit-lua/main/build/fixup.cmake:3 (fixup_bundle)
  /Users/runner/work/32blit-lua/main/build/cmake_install.cmake:51 (include)
```